### PR TITLE
Add timeout parameter for Invoke-D365RestEndpoint

### DIFF
--- a/d365fo.integrations/functions/invoke-d365restendpoint.ps1
+++ b/d365fo.integrations/functions/invoke-d365restendpoint.ps1
@@ -159,7 +159,7 @@ function Invoke-D365RestEndpoint {
         }
 
         # set timeout when specified
-        if ($TimeoutSec > 0) {
+        if ($TimeoutSec -gt 0) {
             $params.TimeoutSec = $TimeoutSec
         }
         

--- a/d365fo.integrations/functions/invoke-d365restendpoint.ps1
+++ b/d365fo.integrations/functions/invoke-d365restendpoint.ps1
@@ -45,6 +45,10 @@
     .PARAMETER EnableException
         This parameters disables user-friendly warnings and enables the throwing of exceptions
         This is less user friendly, but allows catching exceptions in calling scripts
+
+    .PARAMETER TimeoutSec
+        Specifies how long the request can be pending before it times out. Enter a value in seconds. The default value, 0, specifies an indefinite time-out.
+        A Domain Name System (DNS) query can take up to 15 seconds to return or time out. If your request contains a host name that requires resolution, and you set TimeoutSec to a value greater than zero, but less than 15 seconds, it can take 15 seconds or more before a WebException is thrown, and your request times out.
         
     .EXAMPLE
         PS C:\> Invoke-D365RestEndpoint -ServiceName "UserSessionService/AifUserSessionService/GetUserSessionInfo" -Payload "{"RateTypeName": "TEST", "FromCurrency": "DKK", "ToCurrency": "EUR", "StartDate": "2019-01-03T00:00:00Z", "Rate": 745.10, "ConversionFactor": "Hundred", "RateTypeDescription": "TEST"}"
@@ -103,7 +107,10 @@ function Invoke-D365RestEndpoint {
 
         [string] $Token,
         
-        [switch] $EnableException
+        [switch] $EnableException,
+
+        [Parameter(Mandatory = $false)]
+        [int32] $TimeoutSec = 0,
     )
 
     begin {
@@ -149,6 +156,11 @@ function Invoke-D365RestEndpoint {
         }
         else {
             $params.Method = "GET"
+        }
+
+        # set timeout when specified
+        if ($TimeoutSec > 0) {
+            $params.TimeoutSec = $TimeoutSec
         }
         
         try {


### PR DESCRIPTION
Hi!

The default parameter (0) for -TimeoutSec in Invoke-RestEndpoint freezes the service call if something is off.
This PR adds the optional parameter in Invoke-D365RestEndpoint to pass it on to Invoke-RestEndpoint
