### PR TITLE
:heavy_minus_sign: remove unnecessary dependencies

### DIFF
--- a/d365fo.integrations/d365fo.integrations.psd1
+++ b/d365fo.integrations/d365fo.integrations.psd1
@@ -27,8 +27,6 @@
     # this module
     RequiredModules   = @(
         @{ ModuleName = 'PSFramework'; ModuleVersion = '1.0.13' }
-        , @{ ModuleName = 'Azure.Storage'; ModuleVersion = '4.4.0' }
-        ,	@{ ModuleName = 'PSNotification'; ModuleVersion = '0.5.3' }
         ,	@{ ModuleName = 'PSOAuthHelper'; ModuleVersion = '0.3.0' }
     )
 	


### PR DESCRIPTION
Removes the dependency on the PowerShell modules Azure.Storage and PSNotification.
To ensure they are not needed, a search was done across all files of the repo for the commands and their aliases of both modules.

See also #65