### PR TITLE
add .devcontainer and learning notebooks

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,8 @@
 	"customizations": {
 		"vscode": {
 			"extensions": [
-				"ms-vscode.powershell"
+				"ms-vscode.powershell",
+				"ms-dotnettools.dotnet-interactive-vscode"
 			]
 		}
 	}

--- a/README.md
+++ b/README.md
@@ -41,6 +41,17 @@ Update-Module -name d365fo.integrations
 ```
 Update-Module -name d365fo.integrations -Force
 ```
+
+## Learn interactively
+
+We have implemented a **Jupyter Notebook** to help you learn interactively about the different cmdlets / functions available in the module. The notebook is located inside the **'notebooks'** folder in this repository. Click this link [**notebooks**](/notebooks/Get-Started.ipynb) to jump straight inside.
+
+While the notebook is already helpful in itself, its interactive nature will help you learn on another level. To do that, open the notebook in Visual Studio Code with the [Polyglot](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.dotnet-interactive-vscode) extension installed.
+
+The repository also contains a [devcontainer](.devcontainer/devcontainer.json) that has everything installed to run the notebook. The easiest way to get started is to use GitHub Codespaces. Click the button below to start a new Codespace with the repository.
+
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/d365collaborative/d365fo.integrations)
+
 ## **Getting help**
 
 Since the project started we have adopted and extended the comment based help inside each cmdlet / function.

--- a/notebooks/Get-Started.ipynb
+++ b/notebooks/Get-Started.ipynb
@@ -22,7 +22,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {
     "dotnet_interactive": {
      "language": "pwsh"
@@ -31,7 +31,25 @@
      "kernelName": "pwsh"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\u001b[95mUntrusted repository\u001b[0m\n",
+      "You are installing the modules from an untrusted repository. If you trust this repository, change its InstallationPolicy value by running the Set-PSRepository cmdlet. Are you sure you want to install the modules from 'PSGallery'?\n",
+      "[Y] Yes  [A] Yes to All  [N] No  [L] No to All  [S] Suspend  [?] Help(default is 'N')"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "Install-Module d365fo.integrations -Scope CurrentUser"
    ]
@@ -48,7 +66,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {
     "dotnet_interactive": {
      "language": "pwsh"
@@ -84,7 +102,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {
     "dotnet_interactive": {
      "language": "pwsh"
@@ -112,7 +130,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {
     "dotnet_interactive": {
      "language": "pwsh"
@@ -144,7 +162,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {
     "dotnet_interactive": {
      "language": "pwsh"
@@ -169,7 +187,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {
     "dotnet_interactive": {
      "language": "pwsh"
@@ -194,7 +212,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 12,
    "metadata": {
     "dotnet_interactive": {
      "language": "pwsh"
@@ -209,8 +227,10 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "\u001b[32;1mDataEntityName                                 EntityName\u001b[0m\n",
-      "\u001b[32;1m--------------                                 ----------\u001b[0m\n",
+      "\u001b[32;1mDataEntityName                                \u001b[0m\u001b[32;1m EntityName\u001b[0m\n",
+      "\u001b[32;1m--------------                                \u001b[0m \u001b[32;1m----------\u001b[0m\n",
+      "BundleSalesInvoiceBundleParentLine             BundleSalesInvoiceBundleParentLines\n",
+      "BundleSalesInvoiceLine                         BundleSalesInvoiceLines\n",
       "BusinessDocumentSalesInvoiceBase               BusinessDocumentSalesInvoiceBases\n",
       "BusinessDocumentSalesInvoiceLineItem           BusinessDocumentSalesInvoiceLineItems\n",
       "ExternallyMaintainedCustomerSalesInvoiceHeader ExternallyMaintainedCustomerSalesInvoiceHeaders\n",
@@ -219,17 +239,205 @@
       "SalesInvoiceChorusProDetail                    SalesInvoiceChorusProDetails\n",
       "SalesInvoiceHeader                             SalesInvoiceHeaders\n",
       "SalesInvoiceHeaderV2                           SalesInvoiceHeadersV2\n",
+      "SalesInvoiceHeaderV4                           SalesInvoiceHeadersV4\n",
       "SalesInvoiceJournalHeader                      SalesInvoiceJournalHeaders\n",
       "SalesInvoiceLine                               SalesInvoiceLines\n",
       "SalesInvoiceQRCode                             SalesInvoiceQRCode\n",
       "SalesInvoiceV2Line                             SalesInvoiceV2Lines\n",
       "SalesInvoiceV3Line                             SalesInvoiceV3Lines\n",
+      "SalesInvoiceV4Line                             SalesInvoiceV4Lines\n",
       "\n"
      ]
     }
    ],
    "source": [
     "Get-D365ODataPublicEntity -EntityNameContains SalesInvoice -OutNamesOnly"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Learn more about the module\n",
+    "\n",
+    "Now that you know how to install, configure and run a simple command of the module, it is time to learn how you can learn more about the module.\n",
+    "Not every command will have an interactive tutorial like this to explain it. However, each command has documentation that can help you learn how to use it.\n",
+    "To view the documentation for the `Get-D365ODataPublicEntity` cmdlet, run the following command."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "pwsh"
+    },
+    "polyglot_notebook": {
+     "kernelName": "pwsh"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "NAME\n",
+      "    Get-D365ODataPublicEntity\n",
+      "    \n",
+      "SYNOPSIS\n",
+      "    Get public OData Data Entity and their metadata\n",
+      "    \n",
+      "    \n",
+      "SYNTAX\n",
+      "    Get-D365ODataPublicEntity [-EntityName <String>] [-ODataQuery <String>] [-Tenant <String>] \n",
+      "    [-Url <String>] [-SystemUrl <String>] [-ClientId <String>] [-ClientSecret <String>] [-Token \n",
+      "    <String>] [-EnableException] [-RawOutput] [-OutNamesOnly] [-OutputAsJson] [<CommonParameters>]\n",
+      "    \n",
+      "    Get-D365ODataPublicEntity -EntityNameContains <String> [-ODataQuery <String>] [-Tenant \n",
+      "    <String>] [-Url <String>] [-SystemUrl <String>] [-ClientId <String>] [-ClientSecret <String>] \n",
+      "    [-Token <String>] [-EnableException] [-RawOutput] [-OutNamesOnly] [-OutputAsJson] \n",
+      "    [<CommonParameters>]\n",
+      "    \n",
+      "    Get-D365ODataPublicEntity -ODataQuery <String> [-Tenant <String>] [-Url <String>] [-SystemUrl \n",
+      "    <String>] [-ClientId <String>] [-ClientSecret <String>] [-Token <String>] [-EnableException] \n",
+      "    [-RawOutput] [-OutNamesOnly] [-OutputAsJson] [<CommonParameters>]\n",
+      "    \n",
+      "    \n",
+      "DESCRIPTION\n",
+      "    Get a list with all the public available OData Data Entities,and their metadata, that are \n",
+      "    exposed through the OData endpoint of the Dynamics 365 Finance & Operations environment\n",
+      "    \n",
+      "    The cmdlet will search across the singular names for the Data Entities and across the \n",
+      "    collection names (plural)\n",
+      "    \n",
+      "\n",
+      "RELATED LINKS\n",
+      "    Get-D365ODataEntityKey \n",
+      "\n",
+      "REMARKS\n",
+      "    To see the examples, type: \"Get-Help Get-D365ODataPublicEntity -Examples\"\n",
+      "    For more information, type: \"Get-Help Get-D365ODataPublicEntity -Detailed\"\n",
+      "    For technical information, type: \"Get-Help Get-D365ODataPublicEntity -Full\"\n",
+      "    For online help, type: \"Get-Help Get-D365ODataPublicEntity -Online\"\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "Get-Help Get-D365ODataPublicEntity"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As the `REMARKS` section at the end says, you can add some switches to the `Get-Help` cmdlet to get additional information. One of the most useful is the `-Examples` switch that shows you how the cmdlet can be used for different scenarios."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "pwsh"
+    },
+    "polyglot_notebook": {
+     "kernelName": "pwsh"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "NAME\n",
+      "    Get-D365ODataPublicEntity\n",
+      "    \n",
+      "SYNOPSIS\n",
+      "    Get public OData Data Entity and their metadata\n",
+      "    \n",
+      "    \n",
+      "    -------------------------- EXAMPLE 1 --------------------------\n",
+      "    \n",
+      "    PS C:\\>Get-D365ODataPublicEntity -EntityName customersv3\n",
+      "    \n",
+      "    This will get Data Entities from the OData endpoint.\n",
+      "    This will search for the Data Entities that are named \"customersv3\".\n",
+      "    \n",
+      "    \n",
+      "    \n",
+      "    \n",
+      "    -------------------------- EXAMPLE 2 --------------------------\n",
+      "    \n",
+      "    PS C:\\>(Get-D365ODataPublicEntity -EntityName customersv3).Value\n",
+      "    \n",
+      "    This will get Data Entities from the OData endpoint.\n",
+      "    This will search for the Data Entities that are named \"customersv3\".\n",
+      "    This will output the content of the \"Value\" property directly and list all found Data Entities \n",
+      "    and their metadata.\n",
+      "    \n",
+      "    \n",
+      "    \n",
+      "    \n",
+      "    -------------------------- EXAMPLE 3 --------------------------\n",
+      "    \n",
+      "    PS C:\\>Get-D365ODataPublicEntity -EntityNameContains customers\n",
+      "    \n",
+      "    This will get Data Entities from the OData endpoint.\n",
+      "    It will use the search string \"customers\" to search for any entity in their singular & plural \n",
+      "    name contains that search term.\n",
+      "    \n",
+      "    \n",
+      "    \n",
+      "    \n",
+      "    -------------------------- EXAMPLE 4 --------------------------\n",
+      "    \n",
+      "    PS C:\\>Get-D365ODataPublicEntity -EntityNameContains customer -ODataQuery ' and IsReadOnly eq \n",
+      "    true'\n",
+      "    \n",
+      "    This will get Data Entities from the OData endpoint.\n",
+      "    It will use the search string \"customer\" to search for any entity in their singular & plural \n",
+      "    name contains that search term.\n",
+      "    It will utilize the OData Query capabilities to filter for Data Entities that are \"IsReadOnly \n",
+      "    = $true\".\n",
+      "    \n",
+      "    \n",
+      "    \n",
+      "    \n",
+      "    -------------------------- EXAMPLE 5 --------------------------\n",
+      "    \n",
+      "    PS C:\\>Get-D365ODataPublicEntity -EntityName CustomersV3 | Get-D365ODataEntityKey | Format-List\n",
+      "    \n",
+      "    This will extract all the relevant key fields from the Data Entity.\n",
+      "    The \"CustomersV3\" value is used to get the desired Data Entity.\n",
+      "    The output from Get-D365ODataPublicEntity is piped into Get-D365ODataEntityKey.\n",
+      "    All key fields will be extracted and displayed.\n",
+      "    The output will be formatted as a list.\n",
+      "    \n",
+      "    \n",
+      "    \n",
+      "    \n",
+      "    -------------------------- EXAMPLE 6 --------------------------\n",
+      "    \n",
+      "    PS C:\\>$token = Get-D365ODataToken\n",
+      "    PS C:\\> Get-D365ODataPublicEntity -EntityName customersv3 -Token $token\n",
+      "    \n",
+      "    This will get Data Entities from the OData endpoint.\n",
+      "    It will get a fresh token, saved it into the token variable and pass it to the cmdlet.\n",
+      "    This will search for the Data Entities that are named \"customersv3\".\n",
+      "    \n",
+      "    \n",
+      "    \n",
+      "    \n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "Get-Help Get-D365ODataPublicEntity -Examples"
    ]
   }
  ],

--- a/notebooks/Get-Started.ipynb
+++ b/notebooks/Get-Started.ipynb
@@ -130,7 +130,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 15,
    "metadata": {
     "dotnet_interactive": {
      "language": "pwsh"
@@ -438,6 +438,17 @@
    ],
    "source": [
     "Get-Help Get-D365ODataPublicEntity -Examples"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Next steps\n",
+    "\n",
+    "Now that you have successfully run your first cmdlet, you can continue with the other notebooks in this folder to learn more about the d365fo.integrations module and how to use it to integrate with a Dynamics 365 for Finance and Operations environment.\n",
+    "\n",
+    "Take a look at [Learn commands](Learn-Commands.ipynb) to get an introduction to other cmdlets of the module."
    ]
   }
  ],

--- a/notebooks/Get-Started.ipynb
+++ b/notebooks/Get-Started.ipynb
@@ -1,0 +1,259 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Get Started\n",
+    "\n",
+    "This notebook will guide you through the first steps of using the d365fo.integrations module.\n",
+    "\n",
+    "## Prerequisites\n",
+    "\n",
+    "To make full use of this notebook, open it in Visual Studio Code with the PowerShell and Polyglot extensions installed.\n",
+    "\n",
+    "To use the d365fo.integrations PowerShell module, version 5.1 of PowerShell needs to be installed as well. Many cmdlets of the module will also require a D365FO installation and internet access.\n",
+    "\n",
+    "## Installation\n",
+    "\n",
+    "The d365fo.tools module can be installed from the PowerShell Gallery. To do so, run the following PowerShell command:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "pwsh"
+    },
+    "polyglot_notebook": {
+     "kernelName": "pwsh"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "Install-Module d365fo.integrations -Scope CurrentUser"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Non-administrator and administrator installation\n",
+    "\n",
+    "This will install the module in the current user's scope. Many cmdlets will require administrator privileges to run, so it is recommended to install the module in the AllUsers scope instead. To do so, run the following command. Note that you should run Visual Studio Code as administrator to do this. If you later plan to use the module without Visual Studio Code, make sure to open the PowerShell console as administrator as well."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "pwsh"
+    },
+    "polyglot_notebook": {
+     "kernelName": "pwsh"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "Install-Module d365fo.integrations -Scope AllUsers"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Installation prompts\n",
+    "\n",
+    "Either way, the installation may prompt you for questions / confirmations about core PowerShell configurations. You need to either accept or approve all the prompts for the module to work correctly. The prompts usually require you to enter \"y\" (for yes) or \"a\" (for \"yes to all\")."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Importing the module\n",
+    "\n",
+    "Once the module is installed, it can be imported into the current PowerShell session. To do so, run the following command."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "pwsh"
+    },
+    "polyglot_notebook": {
+     "kernelName": "pwsh"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "Import-Module d365fo.integrations"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Using the module\n",
+    "\n",
+    "### Creating a configuration\n",
+    "\n",
+    "Now that the module is imported, you can start using its cmdlets. To get started, you need to define a configuration. Other cmdlets will use the configuration to connect to a D365FO environment to interact with its API endpoints."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "pwsh"
+    },
+    "polyglot_notebook": {
+     "kernelName": "pwsh"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "$Configuration = @{\n",
+    "    Name = \"MyConfig\"\n",
+    "    Tenant = \"someguid-1234-5678-abcd-123456789012\"\n",
+    "    URL = \"https://myd365fotestenvironment.sandbox.operations.dynamics.com\"\n",
+    "    ClientId = \"moreguid-1234-5678-abcd-123456789012\"\n",
+    "    ClientSecret = \"NeverCheckMeIntoVersionControl\"\n",
+    "}\n",
+    "Add-D365ODataConfig @Configuration -Verbose"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Listing configurations\n",
+    "\n",
+    "In case you need to take a look at the configuration that was created at a later time, the `Get-D365ODataConfig` cmdlet can be used."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "pwsh"
+    },
+    "polyglot_notebook": {
+     "kernelName": "pwsh"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "Get-D365ODataConfig"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Setting the active configuration\n",
+    "\n",
+    "Since there can be multiple configurations, we need to let the module know which one it should use. This can be done with the `Set-D365ActiveODataConfig` cmdlet. Note the `-Temporary` switch that tells the module that the active configuration should only be available in the current PowerShell session. Once the session closes, the configuration data will not be available anymore. This should be considered a safety mechanism."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "pwsh"
+    },
+    "polyglot_notebook": {
+     "kernelName": "pwsh"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "Set-D365ActiveODataConfig -Name MyConfig -Temporary"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Getting a list of entities\n",
+    "\n",
+    "Now that we have an active configuration, we can use the module to actually work with the APIs of the D365FO environment identified by the configuration. One often used cmdlet is `Get-D365ODataPublicEntity`, which provides a list of OData entities. The `-EntitynameContains` parameter is used to limit the number of entities (of which there are thousands). The `-OutNamesOnly` switch is used to only list the entity names. Try running the cmdlet without it to get the full information for an entity."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "pwsh"
+    },
+    "polyglot_notebook": {
+     "kernelName": "pwsh"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\u001b[32;1mDataEntityName                                 EntityName\u001b[0m\n",
+      "\u001b[32;1m--------------                                 ----------\u001b[0m\n",
+      "BusinessDocumentSalesInvoiceBase               BusinessDocumentSalesInvoiceBases\n",
+      "BusinessDocumentSalesInvoiceLineItem           BusinessDocumentSalesInvoiceLineItems\n",
+      "ExternallyMaintainedCustomerSalesInvoiceHeader ExternallyMaintainedCustomerSalesInvoiceHeaders\n",
+      "ExternallyMaintainedCustomerSalesInvoiceLine   ExternallyMaintainedCustomerSalesInvoiceLines\n",
+      "ExternallyMaintainedCustomerSalesInvoiceLineV2 ExternallyMaintainedCustomerSalesInvoiceLinesV2\n",
+      "SalesInvoiceChorusProDetail                    SalesInvoiceChorusProDetails\n",
+      "SalesInvoiceHeader                             SalesInvoiceHeaders\n",
+      "SalesInvoiceHeaderV2                           SalesInvoiceHeadersV2\n",
+      "SalesInvoiceJournalHeader                      SalesInvoiceJournalHeaders\n",
+      "SalesInvoiceLine                               SalesInvoiceLines\n",
+      "SalesInvoiceQRCode                             SalesInvoiceQRCode\n",
+      "SalesInvoiceV2Line                             SalesInvoiceV2Lines\n",
+      "SalesInvoiceV3Line                             SalesInvoiceV3Lines\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "Get-D365ODataPublicEntity -EntityNameContains SalesInvoice -OutNamesOnly"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "name": "polyglot-notebook"
+  },
+  "polyglot_notebook": {
+   "kernelInfo": {
+    "defaultKernelName": "csharp",
+    "items": [
+     {
+      "aliases": [],
+      "name": "csharp"
+     }
+    ]
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/notebooks/Learn-Commands.ipynb
+++ b/notebooks/Learn-Commands.ipynb
@@ -1,0 +1,300 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Learn commands\n",
+    "\n",
+    "The d365fo.integrations module contains multiple cmdlets. Use this notebook to learn how to get to know them.\n",
+    "\n",
+    "If this is your first time using this module, take a look at the [Get Started](Get-Started.ipynb) notebook.\n",
+    "\n",
+    "# List the available commands\n",
+    "\n",
+    "To list the available commands, use the `Get-Command` cmdlet."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "pwsh"
+    },
+    "polyglot_notebook": {
+     "kernelName": "pwsh"
+    },
+    "vscode": {
+     "languageId": "polyglot-notebook"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\u001b[32;1mCommandType    \u001b[0m\u001b[32;1m Name                                              \u001b[0m\u001b[32;1m Version   \u001b[0m\u001b[32;1m Source\u001b[0m\n",
+      "\u001b[32;1m-----------    \u001b[0m \u001b[32;1m----                                              \u001b[0m \u001b[32;1m-------   \u001b[0m \u001b[32;1m------\u001b[0m\n",
+      "Function        Add-D365ODataConfig                                0.4.39     d365fo.integrations\n",
+      "Function        Enable-D365ExceptionIntegrations                   0.4.39     d365fo.integrations\n",
+      "Function        Export-D365DmfPackage                              0.4.39     d365fo.integrations\n",
+      "Function        Get-D365ActiveODataConfig                          0.4.39     d365fo.integrations\n",
+      "Function        Get-D365DmfDataEntity                              0.4.39     d365fo.integrations\n",
+      "Function        Get-D365DmfMessageStatus                           0.4.39     d365fo.integrations\n",
+      "Function        Get-D365ODataConfig                                0.4.39     d365fo.integrations\n",
+      "Function        Get-D365ODataEntityData                            0.4.39     d365fo.integrations\n",
+      "Function        Get-D365ODataEntityDataByKey                       0.4.39     d365fo.integrations\n",
+      "Function        Get-D365ODataEntityKey                             0.4.39     d365fo.integrations\n",
+      "Function        Get-D365ODataEntityMandatoryField                  0.4.39     d365fo.integrations\n",
+      "Function        Get-D365ODataEntityUrl                             0.4.39     d365fo.integrations\n",
+      "Function        Get-D365ODataMetadata                              0.4.39     d365fo.integrations\n",
+      "Function        Get-D365ODataPublicEntity                          0.4.39     d365fo.integrations\n",
+      "Function        Get-D365ODataPublicEnum                            0.4.39     d365fo.integrations\n",
+      "Function        Get-D365ODataToken                                 0.4.39     d365fo.integrations\n",
+      "Function        Get-D365ODataTokenInteractive                      0.4.39     d365fo.integrations\n",
+      "Function        Get-D365RestService                                0.4.39     d365fo.integrations\n",
+      "Function        Get-D365RestServiceGroup                           0.4.39     d365fo.integrations\n",
+      "Function        Get-D365RestServiceOperation                       0.4.39     d365fo.integrations\n",
+      "Function        Get-D365RestServiceOperationDetails                0.4.39     d365fo.integrations\n",
+      "Function        Import-D365DmfPackage                              0.4.39     d365fo.integrations\n",
+      "Function        Import-D365ODataEntity                             0.4.39     d365fo.integrations\n",
+      "Function        Import-D365ODataEntityBatchMode                    0.4.39     d365fo.integrations\n",
+      "Function        Invoke-D365DmfInit                                 0.4.39     d365fo.integrations\n",
+      "Function        Invoke-D365ODataEntityAction                       0.4.39     d365fo.integrations\n",
+      "Function        Invoke-D365RestEndpoint                            0.4.39     d365fo.integrations\n",
+      "Function        Remove-D365ODataEntity                             0.4.39     d365fo.integrations\n",
+      "Function        Remove-D365ODataEntityBatchMode                    0.4.39     d365fo.integrations\n",
+      "Function        Set-D365ActiveODataConfig                          0.4.39     d365fo.integrations\n",
+      "Function        Set-D365ODataTokenInSession                        0.4.39     d365fo.integrations\n",
+      "Function        Update-D365ODataEntity                             0.4.39     d365fo.integrations\n",
+      "Function        Update-D365ODataEntityBatchMode                    0.4.39     d365fo.integrations\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "Get-Command -Module d365fo.integrations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Learn more about a cmdlet\n",
+    "\n",
+    "The names of the cmdlets follow the conventions for using a [PowerShell verb](https://docs.microsoft.com/en-us/powershell/scripting/developer/cmdlet/approved-verbs-for-windows-powershell-commands) as the first part of the name. If you are familiar with that convention, you can already guess from the name alone a lot about the purpose of a cmdlet.\n",
+    "\n",
+    "To learn more about a cmdlet, you can use the `Get-Help` cmdlet, which was introduced in [Get Started](Get-Started.ipynb)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "pwsh"
+    },
+    "polyglot_notebook": {
+     "kernelName": "pwsh"
+    },
+    "vscode": {
+     "languageId": "polyglot-notebook"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "NAME\n",
+      "    Add-D365ODataConfig\n",
+      "    \n",
+      "SYNOPSIS\n",
+      "    Save an OData config\n",
+      "    \n",
+      "    \n",
+      "SYNTAX\n",
+      "    Add-D365ODataConfig [-Name] <String> [[-Tenant] <String>] [[-Url] <String>] [[-SystemUrl] \n",
+      "    <String>] [[-ClientId] <String>] [[-ClientSecret] <String>] [-Temporary] [-Force] \n",
+      "    [-EnableException] [<CommonParameters>]\n",
+      "    \n",
+      "    \n",
+      "DESCRIPTION\n",
+      "    Adds an OData config to the configuration store\n",
+      "    \n",
+      "\n",
+      "RELATED LINKS\n",
+      "    Clear-D365ActiveBroadcastMessageConfig \n",
+      "    Get-D365ActiveBroadcastMessageConfig \n",
+      "    Get-D365BroadcastMessageConfig \n",
+      "    Remove-D365BroadcastMessageConfig \n",
+      "    Send-D365BroadcastMessage \n",
+      "    Set-D365ActiveBroadcastMessageConfig \n",
+      "\n",
+      "REMARKS\n",
+      "    To see the examples, type: \"Get-Help Add-D365ODataConfig -Examples\"\n",
+      "    For more information, type: \"Get-Help Add-D365ODataConfig -Detailed\"\n",
+      "    For technical information, type: \"Get-Help Add-D365ODataConfig -Full\"\n",
+      "    For online help, type: \"Get-Help Add-D365ODataConfig -Online\"\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "Get-Help Add-D365ODataConfig"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Authenticate\n",
+    "\n",
+    "Remember that in order to run a cmdlet, you must provide a configuration that the module can use to authenticate with a Dynamics 365 Finance and Operations environment. Review [Get Started](Get-Started.ipynb) on how to do this. For the purpose of this notebook, the following cell is provided to create a configuration and set it as the active one. Note the `-Temporary` switches that will create the configuration only for this PowerShell session, but will not persist them."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "pwsh"
+    },
+    "polyglot_notebook": {
+     "kernelName": "pwsh"
+    },
+    "vscode": {
+     "languageId": "polyglot-notebook"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "$tenantId = Read-Host -Prompt \"Enter your tenant id\"\n",
+    "$clientId = Read-Host -Prompt \"Enter your client id\"\n",
+    "$clientSecret = Read-Host -Prompt \"Enter your client secret\"\n",
+    "$name = Read-Host -Prompt \"Enter a name for the configuration\"\n",
+    "$url = Read-Host -Prompt \"Enter the URL of the D365FO environment\"\n",
+    "\n",
+    "Add-D365ODataConfig -Tenant $tenantId -ClientId $clientId -ClientSecret $clientSecret -Name $name -Url $url -Temporary\n",
+    "Set-D365ActiveODataConfig -Name $name -Temporary"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# The Get cmdlets\n",
+    "\n",
+    "The `Get` cmdlets are used to retrieve information from the Dynamics 365 Finance and Operations environment. They are often easy to use and provide interesting output, which makes them good candidates to explore first.\n",
+    "\n",
+    "To only list the `Get` cmdlets, you can use the `Where-Object` cmdlet to filter the output of `Get-Command`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "pwsh"
+    },
+    "polyglot_notebook": {
+     "kernelName": "pwsh"
+    },
+    "vscode": {
+     "languageId": "polyglot-notebook"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\u001b[32;1mCommandType    \u001b[0m\u001b[32;1m Name                                              \u001b[0m\u001b[32;1m Version   \u001b[0m\u001b[32;1m Source\u001b[0m\n",
+      "\u001b[32;1m-----------    \u001b[0m \u001b[32;1m----                                              \u001b[0m \u001b[32;1m-------   \u001b[0m \u001b[32;1m------\u001b[0m\n",
+      "Function        Get-D365ActiveODataConfig                          0.4.39     d365fo.integrations\n",
+      "Function        Get-D365DmfDataEntity                              0.4.39     d365fo.integrations\n",
+      "Function        Get-D365DmfMessageStatus                           0.4.39     d365fo.integrations\n",
+      "Function        Get-D365ODataConfig                                0.4.39     d365fo.integrations\n",
+      "Function        Get-D365ODataEntityData                            0.4.39     d365fo.integrations\n",
+      "Function        Get-D365ODataEntityDataByKey                       0.4.39     d365fo.integrations\n",
+      "Function        Get-D365ODataEntityKey                             0.4.39     d365fo.integrations\n",
+      "Function        Get-D365ODataEntityMandatoryField                  0.4.39     d365fo.integrations\n",
+      "Function        Get-D365ODataEntityUrl                             0.4.39     d365fo.integrations\n",
+      "Function        Get-D365ODataMetadata                              0.4.39     d365fo.integrations\n",
+      "Function        Get-D365ODataPublicEntity                          0.4.39     d365fo.integrations\n",
+      "Function        Get-D365ODataPublicEnum                            0.4.39     d365fo.integrations\n",
+      "Function        Get-D365ODataToken                                 0.4.39     d365fo.integrations\n",
+      "Function        Get-D365ODataTokenInteractive                      0.4.39     d365fo.integrations\n",
+      "Function        Get-D365RestService                                0.4.39     d365fo.integrations\n",
+      "Function        Get-D365RestServiceGroup                           0.4.39     d365fo.integrations\n",
+      "Function        Get-D365RestServiceOperation                       0.4.39     d365fo.integrations\n",
+      "Function        Get-D365RestServiceOperationDetails                0.4.39     d365fo.integrations\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "Get-Command -Module d365fo.integrations -Verb Get"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You already learned in [Get Started](Get-Started.ipynb) that you can use `Get-D365ODataConfig` to list the available configurations. Can you guess what the `Get-D365ActiveODataConfig` cmdlet does?\n",
+    "\n",
+    "Other `Get` cmdlets cover information and data about OData entities (you already learned about `Get-D365ODataPublicEntity` in, you guessed it, [Get Started](Get-Started.ipynb)), rest services and entities available in the data management framework (DMF) of Dynamics 365 Finance and Operations.\n",
+    "\n",
+    "# Other cmdlets\n",
+    "\n",
+    "The `Get` cmdlets are not the only ones available. Other cmdlets are used to create, update, and delete data, or to perform other operations in the Dynamics 365 Finance and Operations environment. They are however related to the same concepts that the `Get` cmdlets cover. In later, more scenario-focused notebooks, you will learn about them. For now, you can use the `Get-Command` and `Get-Help` cmdlets to explore them. Feel free to use the following cell for your own experiments."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "pwsh"
+    },
+    "polyglot_notebook": {
+     "kernelName": "pwsh"
+    },
+    "vscode": {
+     "languageId": "polyglot-notebook"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# How about getting a list of all Rest services that are available in the \"DMFService\" service group?"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "name": "csharp"
+  },
+  "polyglot_notebook": {
+   "kernelInfo": {
+    "defaultKernelName": "csharp",
+    "items": [
+     {
+      "aliases": [],
+      "name": "csharp"
+     }
+    ]
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/notebooks/ReadMe.md
+++ b/notebooks/ReadMe.md
@@ -1,0 +1,15 @@
+# About the notebooks
+
+This folder contains [Jupyter](https://jupyter.org/) notebooks to learn in an interactive way how to use the d365bap.tools PowerShell module.
+
+The notebooks can be viewed directly on GitHub or other clients that support viewing the Jupyter notebook format. It is however recommended to run them interactively. The easiest way to do so is to use the preconfigured GitHub Codespaces environment: 
+
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/d365collaborative/d365fo.integrations)
+
+To run the notebooks locally, open them in Visual Studio Code with the [Polyglot](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.dotnet-interactive-vscode) extension installed.
+
+## Notebooks
+
+### Getting started
+- [Get started](get-started.ipynb) - Learn how to install the module and get started with the different cmdlets / functions available in the module.
+- [Learn commands](learn-commands.ipynb) - Learn about the different cmdlets / functions available in the module.


### PR DESCRIPTION
Since the latest version no longer has the dependency that prevented the use of d365fo.integrations in a GitHub codespace, I've added a .devcontainer for it along with two polyglot notebooks to learn interactively how to use d365fo.integrations.

More notebooks to come!